### PR TITLE
fix: patch arkworks algebra dependencies to use forked repo with WASM fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,22 +17,19 @@ num = "0.4.0"
 thiserror = "2.0.12"
 
 [patch.crates-io]
-ark-ff = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
-ark-bn254 = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
-ark-grumpkin = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
+ark-bn254 = { git = "https://github.com/dmpierre/algebra.git", branch = "fix/wasm32" }
+ark-grumpkin = { git = "https://github.com/dmpierre/algebra.git", branch = "fix/wasm32" }
+ark-ec = { git = "https://github.com/dmpierre/algebra.git", branch = "fix/wasm32" }
+ark-ff = { git = "https://github.com/dmpierre/algebra.git", branch = "fix/wasm32" }
+ark-serialize = { git = "https://github.com/dmpierre/algebra.git", branch = "fix/wasm32" }
 ark-r1cs-std = { git = "https://github.com/flyingnobita/r1cs-std_yelhousni", rev = "b4bab0c" }         # "perf/sw-updated" branch
 ark-relations = { git = "https://github.com/arkworks-rs/snark" }
 ark-crypto-primitives = { git = "https://github.com/flyingnobita/crypto-primitives", rev = "f559264" }
 ark-std = { git = "https://github.com/arkworks-rs/std" }
-ark-serialize = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
-ark-ec = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
-ark-poly = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
 ark-snark = { git = "https://github.com/arkworks-rs/snark" }
 ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", rev = "b3b4a15" }
 
-# Redirect git dependencies
-[patch."https://github.com/arkworks-rs/algebra.git"]
-ark-ff = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }        # branch fix/wasm32-parallel-cfg-attributes
-ark-ec = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }        # branch fix/wasm32-parallel-cfg-attributes
-ark-serialize = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" } # branch fix/wasm32-parallel-cfg-attributes
-ark-poly = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }      # branch fix/wasm32-parallel-cfg-attributes
+[patch."https://github.com/arkworks-rs/algebra"]
+ark-ec = { git = "https://github.com/dmpierre/algebra.git", branch = "fix/wasm32" }
+ark-ff = { git = "https://github.com/dmpierre/algebra.git", branch = "fix/wasm32" }
+ark-serialize = { git = "https://github.com/dmpierre/algebra.git", branch = "fix/wasm32" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,22 @@ num = "0.4.0"
 thiserror = "2.0.12"
 
 [patch.crates-io]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra" }
-ark-bn254 = { git = "https://github.com/arkworks-rs/algebra" }
-ark-grumpkin = { git = "https://github.com/arkworks-rs/algebra" }
+ark-ff = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
+ark-bn254 = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
+ark-grumpkin = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
 ark-r1cs-std = { git = "https://github.com/flyingnobita/r1cs-std_yelhousni", rev = "b4bab0c" }         # "perf/sw-updated" branch
 ark-relations = { git = "https://github.com/arkworks-rs/snark" }
 ark-crypto-primitives = { git = "https://github.com/flyingnobita/crypto-primitives", rev = "f559264" }
 ark-std = { git = "https://github.com/arkworks-rs/std" }
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra" }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra" }
+ark-serialize = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
+ark-ec = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
+ark-poly = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }  # branch fix/wasm32-parallel-cfg-attributes
 ark-snark = { git = "https://github.com/arkworks-rs/snark" }
 ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", rev = "b3b4a15" }
 
+# Redirect git dependencies
+[patch."https://github.com/arkworks-rs/algebra.git"]
+ark-ff = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }        # branch fix/wasm32-parallel-cfg-attributes
+ark-ec = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }        # branch fix/wasm32-parallel-cfg-attributes
+ark-serialize = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" } # branch fix/wasm32-parallel-cfg-attributes
+ark-poly = { git = "https://github.com/flyingnobita/algebra", rev = "e98a8d3" }      # branch fix/wasm32-parallel-cfg-attributes


### PR DESCRIPTION
## Summary
- Patches arkworks `algebra` dependencies to use `flyingnobita/algebra` fork containing WASM compatibility fix

## Problem
The client WASM build was failing with `ThreadPoolBuildError` when running in browser environments. This was caused by `ark-ec` trying to create rayon thread pools in WASM, where OS threads are not supported.

## Solution
Using a forked version of arkworks `algebra` that includes conditional compilation to bypass thread pool creation when targeting `wasm32` for `ark-ec`. The fix ensures that parallel code paths fall back to sequential execution in WASM environments.

Fix in `ark-ec` [here](https://github.com/flyingnobita/algebra/commit/e98a8d33b97c764909fd79a14310ea3a33586151#diff-9eb8dd3fb68f97287f49932bb9cdb1850fdc03829742fbe1848053844688e41aL542-R558)

Although the problem is specific to the `ark-ec` crate, all crates and Git dependencies that reference the `algebra` repository need to be patched.

## Changes
- Updated `[patch.crates-io]` section to redirect algebra crates to the fork
- Added `[patch."https://github.com/arkworks-rs/algebra.git"]` section to handle git dependencies
- All `algebra` dependencies now consistently use the patched version

## Testing
- [x] Client builds successfully for `wasm32-unknown-unknown` target
- [x] WASM tests run without `rayon` threading errors